### PR TITLE
Fix install.sh issue with test operator

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -17,7 +17,7 @@ esac
 
 arch=`uname -m`
 
-if [[ "$os" = *"UNKNOWN"* ]]
+if echo "$os" | grep -qe '.*UNKNOWN.*'
 then
     echo "Unsupported OS / architecture: ${os}_${arch}"
     exit 1


### PR DESCRIPTION
During installation, following issue can be seen:
```> helm plugin install https://github.com/hayorov/helm-gcs                                                                                                                                                                                       
Installing helm-gcs 0.2.0 ...                                                                                                                                                                                                                   
./scripts/install.sh: 20: ./scripts/install.sh: [[: not found                                                                                                                                                                                   
helm-gcs 0.2.0 is correctly installed. 
```

it's because `[[` does not exist in `/bin/sh`. PR works around it by using grep.