### PR TITLE
Push to Public URL

### DIFF
--- a/cmd/helm-gcs/cmd/push.go
+++ b/cmd/helm-gcs/cmd/push.go
@@ -26,8 +26,10 @@ import (
 )
 
 var (
-	flagForce bool
-	flagRetry bool
+	flagForce     bool
+	flagRetry     bool
+	flagPublic    bool
+	flagPublicURL string
 )
 
 var pushCmd = &cobra.Command{
@@ -41,7 +43,7 @@ var pushCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		return r.PushChart(chartpath, flagForce, flagRetry)
+		return r.PushChart(chartpath, flagForce, flagRetry, flagPublic, flagPublicURL)
 	},
 }
 
@@ -49,4 +51,6 @@ func init() {
 	rootCmd.AddCommand(pushCmd)
 	pushCmd.Flags().BoolVar(&flagForce, "force", false, "upload the chart even if already indexed")
 	pushCmd.Flags().BoolVar(&flagRetry, "retry", false, "retry if the index changed")
+	pushCmd.Flags().BoolVar(&flagPublic, "public", false, "expose HTTP URL instead of default gs:// for public buckets")
+	pushCmd.Flags().StringVar(&flagPublicURL, "publicUrl", "", "used with --public to overwrite google storage default url")
 }


### PR DESCRIPTION
## Description
Add options to the `push` command to set a public URL

Resolves #14 

## Examples
```bash
# URL will be  https://[bucketName].storage.googleapis.com/chart-1.0.0.tgz
helm gcs push chart-1.0.0.tgz repo-name --public

# URL will be  https://my-charts.mydomain/chart-1.0.0.tgz
helm gcs push chart-1.0.0.tgz repo-name --public --publicUrl https://my-charts.mydomain
```