### PR TITLE
Retrieve the Helm repository config path from an environment variable

### DIFF
--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -357,7 +357,7 @@ func resolveReference(base, p string) (string, error) {
 }
 
 func retrieveRepositoryEntry(name string) (*repo.Entry, error) {
-	repoFilePath := helmpath.ConfigPath("repositories.yaml")
+	repoFilePath := envOr("HELM_REPOSITORY_CONFIG", helmpath.ConfigPath("repositories.yaml"))
 	log.Debugf("helm repo file: %s", repoFilePath)
 
 	repoFile, err := repo.LoadFile(repoFilePath)
@@ -383,4 +383,11 @@ func logger() *logrus.Entry {
 	l.SetLevel(level)
 	l.Formatter = &logrus.TextFormatter{}
 	return logrus.NewEntry(l)
+}
+
+func envOr(name, def string) string {
+	if v, ok := os.LookupEnv(name); ok {
+		return v
+	}
+	return def
 }


### PR DESCRIPTION
Helm retrieves its config from environment variables and fallsback to
default paths in case the env vars are unset.
This change mirrors the way helm retrieves the Helm repository
configuration path from the HELM_REPOSITORY_CONFIG environment variable.
Failing that, the default path is used.