### PR TITLE
feat: optionally allow no cache when updating index.yaml so we speed …

### DIFF
--- a/cmd/helm-gcs/cmd/push.go
+++ b/cmd/helm-gcs/cmd/push.go
@@ -26,10 +26,11 @@ import (
 )
 
 var (
-	flagForce     bool
-	flagRetry     bool
-	flagPublic    bool
-	flagPublicURL string
+	flagForce        bool
+	flagRetry        bool
+	flagPublic       bool
+	flagNoIndexCache bool
+	flagPublicURL    string
 )
 
 var pushCmd = &cobra.Command{
@@ -43,7 +44,7 @@ var pushCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		return r.PushChart(chartpath, flagForce, flagRetry, flagPublic, flagPublicURL)
+		return r.PushChart(chartpath, flagForce, flagRetry, flagPublic, flagNoIndexCache, flagPublicURL)
 	},
 }
 
@@ -51,6 +52,7 @@ func init() {
 	rootCmd.AddCommand(pushCmd)
 	pushCmd.Flags().BoolVar(&flagForce, "force", false, "upload the chart even if already indexed")
 	pushCmd.Flags().BoolVar(&flagRetry, "retry", false, "retry if the index changed")
+	pushCmd.Flags().BoolVar(&flagNoIndexCache, "noIndexCache", false, "set Cache-Control to no-cache and max-age to 0, avoids index.yaml being cached to speed up when new helm charts can be fetched")
 	pushCmd.Flags().BoolVar(&flagPublic, "public", false, "expose HTTP URL instead of default gs:// for public buckets")
 	pushCmd.Flags().StringVar(&flagPublicURL, "publicUrl", "", "used with --public to overwrite google storage default url")
 }

--- a/cmd/helm-gcs/cmd/rm.go
+++ b/cmd/helm-gcs/cmd/rm.go
@@ -26,8 +26,9 @@ import (
 )
 
 var (
-	flagVersion string
-	flagRmRetry bool
+	flagVersion        string
+	flagRmRetry        bool
+	flagRmNoIndexCache bool
 )
 
 var rmCmd = &cobra.Command{
@@ -43,7 +44,7 @@ If no specific version is given, all versions will be removed.`,
 		if err != nil {
 			return err
 		}
-		return r.RemoveChart(chart, flagVersion, flagRmRetry)
+		return r.RemoveChart(chart, flagVersion, flagRmRetry, flagRmNoIndexCache)
 	},
 }
 
@@ -51,4 +52,5 @@ func init() {
 	rootCmd.AddCommand(rmCmd)
 	rmCmd.Flags().StringVarP(&flagVersion, "version", "v", "", "version of the chart to remove")
 	rmCmd.Flags().BoolVar(&flagRmRetry, "retry", false, "retry if the index changed")
+	rmCmd.Flags().BoolVar(&flagNoIndexCache, "noIndexCache", false, "set Cache-Control to no-cache and max-age to 0, avoids index.yaml being cached to speed up when new helm charts can be fetched")
 }


### PR DESCRIPTION
…up being able to get the latest released charts

By default gcs enables caching which means it can take a while to be able to `helm fetch` a chart that has been recently released with `helm gcs push`.

There's some more details on cache control here https://cloud.google.com/storage/docs/metadata#cache-control

This PR adds a new flag to avoid caching of the `index.yaml` in GCS, the flag defaults to `false` so that existing behaviour is maintained.  I did wonder if instead the flag should default to `true` because I think most folks would want the chart available straight away?