### PR TITLE
fix: avoid GCS caching the index file

### DIFF
--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -219,6 +219,9 @@ func (r Repo) uploadIndexFile(i *repo.IndexFile) error {
 	if err != nil {
 		return errors.Wrap(err, "writer")
 	}
+	// ensure index.yaml is not cached by GCS
+	w.CacheControl = "no-cache, max-age=0, no-transform"
+
 	b, err := yaml.Marshal(i)
 	if err != nil {
 		return errors.Wrap(err, "marshal")


### PR DESCRIPTION
more details on Caching can be found here https://cloud.google.com/storage/docs/gsutil/addlhelp/WorkingWithObjectMetadata#cache-control_1

Added this PR as Work In Progress while we validate using our pipelines