### PR TITLE
fix(release): provide ARM builds for Apple Silicon

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.16
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,6 +10,7 @@ builds:
       - linux
     goarch:
       - amd64
+      - arm64
     env:
       - CGO_ENABLED=0
 archives:


### PR DESCRIPTION
FWIW `helm plugin install ...` still did not work for me, I had to jump into `~/Library/helm/plugins/helm-gcs/` and:
```shell
% go mod tidy
% go build -o bin/helm-gcs ./cmd/helm-gcs/
```