### PR TITLE
Fix install.sh broken conditional on curl-check

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -28,10 +28,10 @@ url="https://github.com/hayorov/helm-gcs/releases/download/${version}/helm-gcs_$
 filename=`echo ${url} | sed -e "s/^.*\///g"`
 
 # Download archive
-if [ -n $(command -v curl) ]
+if [ -n "$(command -v curl)" ]
 then
     curl -sSL -O $url
-elif [ -n $(command -v wget) ]
+elif [ -n "$(command -v wget)" ]
 then
     wget -q $url
 else


### PR DESCRIPTION
The install.sh L31 condition intends to check for an empty result from the subshell however when curl is missing, without double-quotes surrounding the empty value, the shell evaluates the conditional as `[ -n ]` which is always TRUE. Adding quotes around the subshell ensures that the test will always have a parameter to evaluate. 

Example failure:

>$ helm plugin install https://github.com/hayorov/helm-gcs.git --version 0.3.13
Installing helm-gcs 0.3.13 ...
./scripts/install.sh: line 33: curl: not found
tar: can't open 'helm-gcs_0.3.13_Linux_x86_64.tar.gz': No such file or directory
helm-gcs 0.3.13 is correctly installed.
