### PR TITLE
Ability to specify metadata to objects and pass bucket path

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,20 @@ Now, to push the chart to the repository `my-repository`:
 $ helm gcs push my-chart-<semver>.tgz my-repository
 ```
 
+Push the chart with additional option by providing metadata to the object :
+
+```shell
+$ helm gcs push my-chart-<semver>.tgz my-repository --metadata env=my-env,region=europe-west4
+```
+
+Push the chart with additional option by providing path inside bucket :
+
+This would allow us to structure the content inside the bucket, and stores at `gs://your-bucket/my-application/my-chart-<semver>.tgz`
+
+```shell
+$ helm gcs push my-chart-<semver>.tgz my-repository --bucketPath=my-application
+```
+
 If you got this error:
 
 ```shell

--- a/cmd/helm-gcs/cmd/push.go
+++ b/cmd/helm-gcs/cmd/push.go
@@ -26,10 +26,12 @@ import (
 )
 
 var (
-	flagForce     bool
-	flagRetry     bool
-	flagPublic    bool
-	flagPublicURL string
+	flagForce      bool
+	flagRetry      bool
+	flagPublic     bool
+	flagPublicURL  string
+	flagBucketPath string
+	flagMetadata   map[string]string
 )
 
 var pushCmd = &cobra.Command{
@@ -43,7 +45,7 @@ var pushCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		return r.PushChart(chartpath, flagForce, flagRetry, flagPublic, flagPublicURL)
+		return r.PushChart(chartpath, flagForce, flagRetry, flagPublic, flagPublicURL, flagBucketPath, flagMetadata)
 	},
 }
 
@@ -53,4 +55,6 @@ func init() {
 	pushCmd.Flags().BoolVar(&flagRetry, "retry", false, "retry if the index changed")
 	pushCmd.Flags().BoolVar(&flagPublic, "public", false, "expose HTTP URL instead of default gs:// for public buckets")
 	pushCmd.Flags().StringVar(&flagPublicURL, "publicUrl", "", "used with --public to overwrite google storage default url")
+	pushCmd.Flags().StringVar(&flagBucketPath, "bucketPath", "", "path inside the google bucket")
+	pushCmd.Flags().StringToStringVar(&flagMetadata, "metadata", nil, "comma seperated object metadata in the form of key=value")
 }

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: "gcs"
-version: "0.3.14"
+version: "0.3.15"
 usage: "Chart repositories on Google Cloud Storage"
 description: |-
   Manage repositories on Google Cloud Storage


### PR DESCRIPTION
Hello @hayorov 👋 
Following are the features added as part of this PR

**1. Metadata to objects:**
While pushing the chart, a new flag `--metadata mykey1=myvalue1,mykey2=myvalue2` will allow users to specify custom metadata to the helm-charts object.
Use-Case:
While using pub-sub or any kind of trigger mechanism to detect changes to the objects in the bucket, this feature will allow end-users to manage the flow based on metadata of the object, if necessary.

**2. Path inside bucket:**
This will allow users to structure how objects could be stored inside the bucket by providing additional flag `--bucketPath=app-one` while pushing the chart. 
Eg:
```
gs://mybucket/
    - index.yaml
    - app-one/
          - app-one-0.0.1.tgz
          - app-one-0.0.2.tgz
    - app-two/
          - app-two-0.0.1.tgz
          - app-two-0.0.2.tgz
```

Cheers!