### PR TITLE
Allow GCS authentication with OAuth Access Token

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ To authenticate against GCS you can:
 
 - Use a service account via [`export GOOGLE_APPLICATION_CREDENTIALS=credentials.json` system variable](https://cloud.google.com/docs/authentication/getting-started)
 
+- Use a temporary [OAuth 2.0 access token](https://developers.google.com/identity/protocols/oauth2) via `export GOOGLE_OAUTH_ACCESS_TOKEN=<MY_ACCESS_TOKEN>` environment variable. When used, plugin will ignore other authentification methods.
+
 See [GCP documentation](https://cloud.google.com/docs/authentication/production#providing_credentials_to_your_application) for more information.
 
 ### Create a repository

--- a/pkg/gcs/gcs.go
+++ b/pkg/gcs/gcs.go
@@ -20,8 +20,7 @@ func NewClient(serviceAccountPath string) (*storage.Client, error) {
 	if token != "" {
 		token := &oauth2.Token{AccessToken: token}
 		opts = append(opts, option.WithTokenSource(oauth2.StaticTokenSource(token)))
-	}
-	if serviceAccountPath != "" {
+	} else if serviceAccountPath != "" {
 		opts = append(opts, option.WithCredentialsFile(serviceAccountPath))
 	}
 	client, err := storage.NewClient(context.Background(), opts...)

--- a/pkg/gcs/gcs.go
+++ b/pkg/gcs/gcs.go
@@ -3,16 +3,24 @@ package gcs
 import (
 	"context"
 	"net/url"
+	"os"
 
 	"cloud.google.com/go/storage"
 	"github.com/pkg/errors"
+	"golang.org/x/oauth2"
 	"google.golang.org/api/option"
 )
 
 // NewClient creates a new gcs client.
 // Use Application Default Credentials if serviceAccount is empty.
+// Ignores ADC or serviceAccount when GOOGLE_OAUTH_ACCESS_TOKEN env variable is exported.
 func NewClient(serviceAccountPath string) (*storage.Client, error) {
 	opts := []option.ClientOption{}
+	token := os.Getenv("GOOGLE_OAUTH_ACCESS_TOKEN")
+	if token != "" {
+		token := &oauth2.Token{AccessToken: token}
+		opts = append(opts, option.WithTokenSource(oauth2.StaticTokenSource(token)))
+	}
 	if serviceAccountPath != "" {
 		opts = append(opts, option.WithCredentialsFile(serviceAccountPath))
 	}

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: "gcs"
-version: "0.3.19"
+version: "0.3.20"
 usage: "Chart repositories on Google Cloud Storage"
 description: |-
   Manage repositories on Google Cloud Storage


### PR DESCRIPTION
When running CICD on-prem often users would avoid keeping SA credentials file on CICD servers/executors due to security reasons and instead rely on auth broker like [Hashicorp Vault](https://www.vaultproject.io/docs/auth/gcp) for OAuth access token generation. GCLOUD already supports [auth via access token ](https://cloud.google.com/sdk/gcloud/reference#--access-token-file), I'd like to contribute a change which allow the same for `helm-gcs` plugin.

These are not breaking changes and have been tested locally. 