### PR TITLE
General improvements for Terraform users

### DIFF
--- a/pkg/gcs/gcs.go
+++ b/pkg/gcs/gcs.go
@@ -17,9 +17,13 @@ import (
 func NewClient(serviceAccountPath string) (*storage.Client, error) {
 	opts := []option.ClientOption{}
 	token := os.Getenv("GOOGLE_OAUTH_ACCESS_TOKEN")
+	envCreds := os.Getenv("GOOGLE_CREDENTIALS") // used by terraform google provider
+	ignoreEnvCreds := os.Getenv("HELM_GCS_IGNORE_TERRAFORM_CREDS")
 	if token != "" {
 		token := &oauth2.Token{AccessToken: token}
 		opts = append(opts, option.WithTokenSource(oauth2.StaticTokenSource(token)))
+	} else if envCreds != "" && ignoreEnvCreds != "true" {
+		opts = append(opts, option.WithCredentialsJSON([]byte(envCreds)))
 	} else if serviceAccountPath != "" {
 		opts = append(opts, option.WithCredentialsFile(serviceAccountPath))
 	}
@@ -30,7 +34,7 @@ func NewClient(serviceAccountPath string) (*storage.Client, error) {
 	return client, err
 }
 
-// Object retourne a new object handle for the given path
+// Object returns a new object handle for the given path
 func Object(client *storage.Client, path string) (*storage.ObjectHandle, error) {
 	bucket, path, err := splitPath(path)
 	if err != nil {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -5,27 +5,35 @@ version="$(cat plugin.yaml | grep "version" | cut -d '"' -f 2)"
 echo "Installing helm-gcs ${version} ..."
 
 # Find correct archive name
-unameOut="$(uname -s)"
+unameOsOut="$(uname -s)"
+if [ "${HELM_OS}" ]; then
+  unameOsOut="${HELM_OS}"
+fi
 
-case "${unameOut}" in
-    Linux*)             os=Linux;;
-    Darwin*)            os=Darwin;;
-    CYGWIN*)            os=Cygwin;;
-    MINGW*|MSYS_NT*)    os=windows;;
-    *)                  os="UNKNOWN:${unameOut}"
+case "${unameOsOut}" in
+    Linux*|linux*)                      os=Linux;;
+    Darwin*|darwin*)                    os=Darwin;;
+    CYGWIN*|cygwin*)                    os=Cygwin;;
+    MINGW*|MSYS_NT*|mingw*|msys_nt*)    os=windows;;
+    *)                                  os="UNKNOWN_OS:${unameOsOut}"
 esac
 
-arch=`uname -m`
+unameArchOut=`uname -m`
+if [ "${HELM_ARCH}" ]
+then
+  unameArchOut="${HELM_ARCH}"
+fi
 
-if echo "$os" | grep -qe '.*UNKNOWN.*'
+case "${unameArchOut}" in
+  aarch64|arm64)  arch="arm64";;
+  amd64|x86_64)   arch="x86_64";;
+  *)              arch="UNKNOWN_ARCH:${arch}"
+esac
+
+if echo "${os}${arch}" | grep -qe '.*UNKNOWN.*'
 then
     echo "Unsupported OS / architecture: ${os}_${arch}"
     exit 1
-fi
-
-if [ "$arch" = 'aarch64' ]
-then
-    arch='arm64'
 fi
 
 url="https://github.com/hayorov/helm-gcs/releases/download/${version}/helm-gcs_${version}_${os}_${arch}.tar.gz"


### PR DESCRIPTION
- if the `GOOGLE_CREDENTIALS` environment variable is non-empty, attempt to read the service account key JSON from it, unless the `HELM_GCS_IGNORE_TERRAFORM_CREDS` environment variable is set to `true`

- allow overriding the local host OS and architecture in the install script by setting the `HELM_OS` and `HELM_ARCH` environment variables

- add extensive documentation to the README on the sadly non-obvious steps necessary to use the plugin inside of Terraform