### PR TITLE
fix: install asset url since 0.5.0

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -28,7 +28,7 @@ then
     arch='arm64'
 fi
 
-url="https://github.com/hayorov/helm-gcs/releases/download/${version}/helm-gcs_${version}_${os}_${arch}.tar.gz"
+url="https://github.com/hayorov/helm-gcs/releases/download/${version}/helm-gcs_${os}_${arch}.tar.gz"
 
 filename=`echo ${url} | sed -e "s/^.*\///g"`
 


### PR DESCRIPTION
Hey @hayorov ! Since 0.5.0, the filename in assets doesn't include version, and it breaks install.

Thanks for software sir!

Br, Alexey