### PR TITLE
fix: gcs-getter's plugin.yaml in Helm4 install script  

### DIFF
--- a/scripts/install-helm4.sh
+++ b/scripts/install-helm4.sh
@@ -94,8 +94,11 @@ config:
     - gs
 
 runtimeConfig:
-  platformCommand:
-    - command: "\${HELM_PLUGIN_DIR}/bin/${binary}"
+  protocolCommands:
+  - protocols:
+      - gs
+    platformCommand:
+      - command: "bin/${binary}"
 EOF
     fi
     


### PR DESCRIPTION
Addresses https://github.com/hayorov/helm-gcs/issues/251

Turns out 2 things.
1) Even when given an absolute path, the getter plugins append the path instead of treating it as an asbolute.
I assume this is a security decision by helm to enforce that the getters can only run the commands that were shipped with the plugin. 

This could be considered a bug in the getter runtime stuff though, because, the cli plugins don't work this way.

What happens when I use the ${HELM_PLUGIN_DIR} is that I wind up with an error like this:
`failed to invoke: fork/exec /home/mark/.local/share/helm/plugins/gcs-getter/home/mark/.local/share/helm/plugins/gcs-getter/bin/helm-gcs-getter: no such file or directory`
The plugin lives in `/home/mark/.local/share/helm/plugins/gcs-getter` and that is the same value of `HELM_PLUGIN_DIR` but it's just appending it instead of replacing it.

Again, the CLI runtime part of their code doesn't do that... 

2) Their getter runtime loops an array, named `protocolCommands`, of maps until it finds a map that has an array named `protocols` that contains the matching protocl. Once it finds that map, then it checks that maps platformCommand.