### PR TITLE
fix: Windows install support and Helm 3.18+ compatibility

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -7,8 +7,7 @@ description: |-
   Manage repositories on Google Cloud Storage
 command: "$HELM_PLUGIN_DIR/bin/helm-gcs"
 downloaders:
-  - command: "$HELM_PLUGIN_DIR/bin/helm-gcs"
-    args: ["pull"]
+  - command: "bin/helm-gcs-getter"
     protocols:
       - "gs"
 hooks:

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,15 +1,34 @@
-# Legacy plugin.yaml for Helm 3 compatibility
-# For Helm 4, use the separate plugins in plugins/gcs/ and plugins/gcs-getter/
 name: "gcs"
 version: "0.7.0"
 usage: "Chart repositories on Google Cloud Storage"
 description: |-
   Manage repositories on Google Cloud Storage
-command: "$HELM_PLUGIN_DIR/bin/helm-gcs"
+platformCommand:
+  - command: "$HELM_PLUGIN_DIR/bin/helm-gcs"
+  - os: windows
+    command: "$HELM_PLUGIN_DIR\\bin\\helm-gcs.exe"
 downloaders:
   - command: "bin/helm-gcs-getter"
     protocols:
       - "gs"
-hooks:
-  install: "cd $HELM_PLUGIN_DIR; ./scripts/install.sh"
-  update: "cd $HELM_PLUGIN_DIR; ./scripts/install.sh"
+platformHooks:
+  install:
+    - command: "$HELM_PLUGIN_DIR/scripts/install.sh"
+    - os: windows
+      command: "powershell.exe"
+      args:
+        - "-NoProfile"
+        - "-ExecutionPolicy"
+        - "Bypass"
+        - "-File"
+        - "$HELM_PLUGIN_DIR\\scripts\\install.ps1"
+  update:
+    - command: "$HELM_PLUGIN_DIR/scripts/install.sh"
+    - os: windows
+      command: "powershell.exe"
+      args:
+        - "-NoProfile"
+        - "-ExecutionPolicy"
+        - "Bypass"
+        - "-File"
+        - "$HELM_PLUGIN_DIR\\scripts\\install.ps1"

--- a/plugins/gcs-getter/scripts/install.sh
+++ b/plugins/gcs-getter/scripts/install.sh
@@ -45,8 +45,14 @@ case "$arch" in
         ;;
 esac
 
-url="https://github.com/hayorov/helm-gcs/releases/download/v${version}/helm-gcs-getter_${os}_${arch}.tar.gz"
-filename="helm-gcs-getter_${os}_${arch}.tar.gz"
+if [ "$os" = "Windows" ]; then
+    ext="zip"
+else
+    ext="tar.gz"
+fi
+
+url="https://github.com/hayorov/helm-gcs/releases/download/v${version}/helm-gcs-getter_${os}_${arch}.${ext}"
+filename="helm-gcs-getter_${os}_${arch}.${ext}"
 
 echo "Downloading from: ${url}"
 
@@ -67,11 +73,19 @@ else
     exit 1
 fi
 
-tar xzf "$filename" -C bin || {
-    echo "Error: Failed to extract $filename"
-    rm -f "$filename"
-    exit 1
-}
+if [ "$ext" = "zip" ]; then
+    unzip -q -o "$filename" -d bin || {
+        echo "Error: Failed to extract $filename"
+        rm -f "$filename"
+        exit 1
+    }
+else
+    tar xzf "$filename" -C bin || {
+        echo "Error: Failed to extract $filename"
+        rm -f "$filename"
+        exit 1
+    }
+fi
 
 rm -f "$filename"
 

--- a/plugins/gcs/scripts/install.sh
+++ b/plugins/gcs/scripts/install.sh
@@ -45,8 +45,14 @@ case "$arch" in
         ;;
 esac
 
-url="https://github.com/hayorov/helm-gcs/releases/download/v${version}/helm-gcs_${os}_${arch}.tar.gz"
-filename="helm-gcs_${os}_${arch}.tar.gz"
+if [ "$os" = "Windows" ]; then
+    ext="zip"
+else
+    ext="tar.gz"
+fi
+
+url="https://github.com/hayorov/helm-gcs/releases/download/v${version}/helm-gcs_${os}_${arch}.${ext}"
+filename="helm-gcs_${os}_${arch}.${ext}"
 
 echo "Downloading from: ${url}"
 
@@ -67,11 +73,19 @@ else
     exit 1
 fi
 
-tar xzf "$filename" -C bin || {
-    echo "Error: Failed to extract $filename"
-    rm -f "$filename"
-    exit 1
-}
+if [ "$ext" = "zip" ]; then
+    unzip -q -o "$filename" -d bin || {
+        echo "Error: Failed to extract $filename"
+        rm -f "$filename"
+        exit 1
+    }
+else
+    tar xzf "$filename" -C bin || {
+        echo "Error: Failed to extract $filename"
+        rm -f "$filename"
+        exit 1
+    }
+fi
 
 rm -f "$filename"
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,124 @@
+$ErrorActionPreference = "Stop"
+
+# Ensure we're in the plugin directory
+if (-not $env:HELM_PLUGIN_DIR) {
+    Write-Error "HELM_PLUGIN_DIR is not set"
+    exit 1
+}
+
+Set-Location $env:HELM_PLUGIN_DIR
+
+# Extract version from plugin.yaml
+if (-not (Test-Path "plugin.yaml")) {
+    Write-Error "plugin.yaml not found in $env:HELM_PLUGIN_DIR"
+    exit 1
+}
+
+$versionLine = Select-String -Path "plugin.yaml" -Pattern 'version:' | Select-Object -First 1
+if (-not $versionLine) {
+    Write-Error "Could not extract version from plugin.yaml"
+    exit 1
+}
+$version = ($versionLine.Line -replace '.*version:\s*"?([^"]+)"?.*', '$1').Trim()
+if (-not $version) {
+    Write-Error "Could not extract version from plugin.yaml"
+    exit 1
+}
+
+# Detect Helm version using $HELM_BIN (set by Helm itself) to avoid
+# picking up a different helm version that happens to be on PATH.
+$helmBin = if ($env:HELM_BIN) { $env:HELM_BIN } else { "helm" }
+$helmMajorVersion = ""
+try {
+    $helmVersionOutput = & $helmBin version --short 2>$null
+    if ($helmVersionOutput -match 'v(\d+)') {
+        $helmMajorVersion = $Matches[1]
+    }
+} catch {
+    # helm not found or version failed; fall through
+}
+
+# For Helm 4, recommend using the separate plugin packages
+if ($helmMajorVersion -eq "4") {
+    Write-Host ""
+    Write-Host "=========================================="
+    Write-Host "  Helm 4 Detected"
+    Write-Host "=========================================="
+    Write-Host ""
+    Write-Host "For Helm 4, we recommend installing the separate plugin packages"
+    Write-Host "for better compatibility with the new plugin system:"
+    Write-Host ""
+    Write-Host "  # CLI plugin (helm gcs init/push/rm)"
+    Write-Host "  helm plugin install https://github.com/hayorov/helm-gcs/releases/download/v${version}/helm-gcs-plugin.tar.gz"
+    Write-Host ""
+    Write-Host "  # Getter plugin (gs:// protocol support)"
+    Write-Host "  helm plugin install https://github.com/hayorov/helm-gcs/releases/download/v${version}/helm-gcs-getter-plugin.tar.gz"
+    Write-Host ""
+    Write-Host "Continuing with legacy installation..."
+    Write-Host ""
+}
+
+Write-Host "Installing helm-gcs ${version} ..."
+
+# Detect architecture
+$arch = switch ($env:PROCESSOR_ARCHITECTURE) {
+    "AMD64"  { "x86_64" }
+    "ARM64"  { "arm64" }
+    default  {
+        Write-Error "Unsupported architecture: $env:PROCESSOR_ARCHITECTURE"
+        exit 1
+    }
+}
+
+$baseUrl = "https://github.com/hayorov/helm-gcs/releases/download/v${version}"
+
+if (Test-Path "bin") {
+    Remove-Item -Recurse -Force "bin"
+}
+New-Item -ItemType Directory -Path "bin" | Out-Null
+
+foreach ($binary in @("helm-gcs", "helm-gcs-getter")) {
+    $filename = "${binary}_Windows_${arch}.zip"
+    $url = "${baseUrl}/${filename}"
+
+    Write-Host "Downloading from: ${url}"
+
+    try {
+        Invoke-WebRequest -Uri $url -OutFile $filename -UseBasicParsing
+    } catch {
+        Write-Error "Failed to download ${url}: $_"
+        exit 1
+    }
+
+    try {
+        Expand-Archive -Path $filename -DestinationPath "bin" -Force
+    } catch {
+        Remove-Item -Force $filename -ErrorAction SilentlyContinue
+        Write-Error "Failed to extract ${filename}: $_"
+        exit 1
+    }
+
+    Remove-Item -Force $filename -ErrorAction SilentlyContinue
+}
+
+# Verify installation
+if (-not (Test-Path "bin\helm-gcs.exe")) {
+    Write-Error "helm-gcs.exe binary not found after extraction"
+    exit 1
+}
+
+if (-not (Test-Path "bin\helm-gcs-getter.exe")) {
+    Write-Error "helm-gcs-getter.exe binary not found after extraction"
+    exit 1
+}
+
+Write-Host ""
+Write-Host "helm-gcs ${version} is correctly installed."
+Write-Host ""
+Write-Host "Usage:"
+Write-Host "  helm gcs init gs://bucket/path              # Initialize repository"
+Write-Host "  helm repo add repo-name gs://bucket/path    # Add repository to Helm"
+Write-Host "  helm gcs push chart.tgz repo-name           # Push a chart"
+Write-Host "  helm repo update                            # Update Helm cache"
+Write-Host "  helm fetch repo-name/chart                  # Fetch a chart"
+Write-Host ""

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -60,7 +60,7 @@ case "${unameOut}" in
     Linux*)             os=Linux;;
     Darwin*)            os=Darwin;;
     CYGWIN*)            os=Cygwin;;
-    MINGW*|MSYS_NT*)    os=windows;;
+    MINGW*|MSYS_NT*)    os=Windows;;
     *)
         echo "Unsupported OS: ${unameOut}"
         exit 1
@@ -79,48 +79,71 @@ case "${arch}" in
         ;;
 esac
 
-url="https://github.com/hayorov/helm-gcs/releases/download/v${version}/helm-gcs_${os}_${arch}.tar.gz"
-filename="helm-gcs_${os}_${arch}.tar.gz"
-
-echo "Downloading from: ${url}"
-
-# Download archive
-if command -v curl > /dev/null 2>&1; then
-    if ! curl -sSL -o "$filename" "$url"; then
-        echo "Error: Failed to download $url"
-        exit 1
-    fi
-elif command -v wget > /dev/null 2>&1; then
-    if ! wget -q -O "$filename" "$url"; then
-        echo "Error: Failed to download $url"
-        exit 1
-    fi
+if [ "$os" = "Windows" ]; then
+    ext="zip"
 else
-    echo "Error: curl or wget is required"
-    exit 1
+    ext="tar.gz"
 fi
 
-# Verify download
-if [ ! -f "$filename" ]; then
-    echo "Error: Downloaded file not found: $filename"
-    exit 1
-fi
-
-# Install binary
 rm -rf bin
 mkdir -p bin
 
-if ! tar xzf "$filename" -C bin; then
-    echo "Error: Failed to extract $filename"
+base_url="https://github.com/hayorov/helm-gcs/releases/download/v${version}"
+
+for binary in helm-gcs helm-gcs-getter; do
+    filename="${binary}_${os}_${arch}.${ext}"
+    url="${base_url}/${filename}"
+
+    echo "Downloading from: ${url}"
+
+    # Download archive
+    if command -v curl > /dev/null 2>&1; then
+        if ! curl -sSL -o "$filename" "$url"; then
+            echo "Error: Failed to download $url"
+            exit 1
+        fi
+    elif command -v wget > /dev/null 2>&1; then
+        if ! wget -q -O "$filename" "$url"; then
+            echo "Error: Failed to download $url"
+            exit 1
+        fi
+    else
+        echo "Error: curl or wget is required"
+        exit 1
+    fi
+
+    # Verify download
+    if [ ! -f "$filename" ]; then
+        echo "Error: Downloaded file not found: $filename"
+        exit 1
+    fi
+
+    # Extract archive
+    if [ "$ext" = "zip" ]; then
+        if ! unzip -q -o "$filename" -d bin; then
+            echo "Error: Failed to extract $filename"
+            rm -f "$filename"
+            exit 1
+        fi
+    else
+        if ! tar xzf "$filename" -C bin; then
+            echo "Error: Failed to extract $filename"
+            rm -f "$filename"
+            exit 1
+        fi
+    fi
+
     rm -f "$filename"
+done
+
+# Verify installation
+if [ ! -x "bin/helm-gcs" ] && [ ! -f "bin/helm-gcs.exe" ]; then
+    echo "Error: helm-gcs binary not found or not executable"
     exit 1
 fi
 
-rm -f "$filename"
-
-# Verify installation
-if [ ! -x "bin/helm-gcs" ]; then
-    echo "Error: helm-gcs binary not found or not executable"
+if [ ! -x "bin/helm-gcs-getter" ] && [ ! -f "bin/helm-gcs-getter.exe" ]; then
+    echo "Error: helm-gcs-getter binary not found or not executable"
     exit 1
 fi
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -25,10 +25,12 @@ if [ -z "$version" ]; then
     exit 1
 fi
 
-# Detect Helm version
+# Detect Helm version using $HELM_BIN (set by Helm itself) to avoid
+# picking up a different helm version that happens to be on PATH.
 helm_major_version=""
-if command -v helm > /dev/null 2>&1; then
-    helm_version_output=$(helm version --short 2>/dev/null || echo "")
+helm_bin="${HELM_BIN:-helm}"
+if command -v "$helm_bin" > /dev/null 2>&1; then
+    helm_version_output=$("$helm_bin" version --short 2>/dev/null || echo "")
     helm_major_version=$(echo "$helm_version_output" | grep -oE 'v[0-9]+' | head -1 | tr -d 'v')
 fi
 


### PR DESCRIPTION
install.sh maps MINGW/MSYS to lowercase 'windows' but GoReleaser uses title-case 'Windows', so the download URL 404s. It also unconditionally uses tar, but GoReleaser produces .zip for Windows.

Separately, the downloaders 'args' field in plugin.yaml doesn't exist in Helm 3's Downloaders struct. Helm 3.18+ strict-unmarshals plugin.yaml, so this is a fatal parse error.

This change fixes the casing on 'windows', adds zip/unzip handling, and switches the downloaders command to bin/helm-gcs-getter (the purpose-built getter binary). This drops the need for 'args' and works cross-platform. The root install script now also downloads helm-gcs-getter since it's needed.

Originally (first commit), this PR relied on git bash for Windows users to run the install shell script. But when I tested this with a colleague on Windows, his git bash wasn't in his PATH, and it failed on the shell script. Given git bash apparently isn't that reliable on Windows, the second commit replaces the install scripts for windows with powershell scripts, which will 100% be in the PATH on windows machines. It worked for me and my colleague.