### PR TITLE
Feature/helm4 subplugin tarballs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,3 +67,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
         if: ${{ steps.import_gpg.outputs.fingerprint != '' }}
+      - name: Package and upload Helm 4 sub-plugin tarballs
+        run: |
+          tag="${GITHUB_REF#refs/tags/}"
+          cp -r plugins/gcs helm-gcs-plugin
+          tar czf helm-gcs-plugin.tar.gz helm-gcs-plugin
+          cp -r plugins/gcs-getter helm-gcs-getter-plugin
+          tar czf helm-gcs-getter-plugin.tar.gz helm-gcs-getter-plugin
+          gh release upload "$tag" helm-gcs-plugin.tar.gz helm-gcs-getter-plugin.tar.gz
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -84,44 +84,37 @@ Store, version, and distribute your Helm charts on GCS with the same ease and se
 
 ## 📦 Installation
 
-### Helm 4
+The install source is the same for Helm 3 and Helm 4:
 
-**One-line install** (recommended):
+- Helm 4 installs the native `gcs` + `gcs-getter` plugin pair automatically
+- Helm 3 installs the legacy single-plugin layout automatically
 
-```bash
-curl -fsSL https://raw.githubusercontent.com/hayorov/helm-gcs/master/scripts/install-helm4.sh | sh
-```
-
-Or specify a version:
+### Install Latest
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/hayorov/helm-gcs/master/scripts/install-helm4.sh | HELM_GCS_VERSION=0.7.0 sh
+# Helm 4
+helm plugin install https://github.com/hayorov/helm-gcs.git --verify=false
+
+# Helm 3
+helm plugin install https://github.com/hayorov/helm-gcs.git
 ```
 
-This installs both required plugins:
-- **gcs** (CLI) - provides `helm gcs init/push/rm` commands
-- **gcs-getter** (Getter) - provides `gs://` protocol support
+This installs:
+- Helm 4: `gcs` (CLI) and `gcs-getter` (Getter)
+- Helm 3: `gcs` (single combined plugin)
 
 Verify installation:
 
 ```bash
 helm plugin list
-# NAME        VERSION  TYPE       APIVERSION  PROVENANCE  SOURCE
-# gcs         0.7.0    cli/v1     v1          verified    https://github.com/hayorov/helm-gcs
-# gcs-getter  0.7.0    getter/v1  v1          verified    https://github.com/hayorov/helm-gcs
-```
-
-### Helm 3
-
-```bash
-helm plugin install https://github.com/hayorov/helm-gcs.git
+helm gcs version
 ```
 
 ### Install Specific Version
 
 ```bash
-# Helm 4 (specify version via environment variable)
-curl -fsSL https://raw.githubusercontent.com/hayorov/helm-gcs/master/scripts/install-helm4.sh | HELM_GCS_VERSION=0.7.0 sh
+# Helm 4
+helm plugin install https://github.com/hayorov/helm-gcs.git --version 0.7.0 --verify=false
 
 # Helm 3
 helm plugin install https://github.com/hayorov/helm-gcs.git --version 0.7.0
@@ -450,7 +443,7 @@ helm gcs push --help
 
 ### Helm 4 Architecture
 
-Helm 4 enforces a strict "one plugin = one type" model. A single plugin cannot be both a CLI plugin and a Getter plugin. Therefore, helm-gcs 0.7.0+ provides two separate plugins:
+Helm 4 enforces a strict "one plugin = one type" model. A single plugin cannot be both a CLI plugin and a Getter plugin. helm-gcs 0.7.0+ keeps the install command the same as Helm 3, but installs two separate plugins automatically on Helm 4:
 
 | Plugin | Type | Purpose |
 |--------|------|---------|
@@ -459,7 +452,7 @@ Helm 4 enforces a strict "one plugin = one type" model. A single plugin cannot b
 
 ### Helm 3 Compatibility
 
-Helm 3 uses a combined plugin model where one plugin handles both CLI commands and protocol downloading. helm-gcs 0.7.x maintains full backward compatibility:
+Helm 3 uses a combined plugin model where one plugin handles both CLI commands and protocol downloading. helm-gcs 0.7.x keeps full backward compatibility while sharing the same repository install URL as Helm 4:
 
 ```bash
 # Install for Helm 3
@@ -470,9 +463,9 @@ helm gcs init gs://bucket/charts      # CLI commands
 helm repo add myrepo gs://bucket/charts  # gs:// protocol
 ```
 
-The legacy `plugin.yaml` at the repository root provides Helm 3 compatibility by:
-- Registering CLI commands via `command` field
-- Registering `gs://` protocol via `downloaders` field
+The repository root `plugin.yaml` is used as a bootstrap entrypoint for both Helm 3 and Helm 4:
+- Helm 3 keeps the legacy combined plugin layout
+- Helm 4 installs the native `gcs` and `gcs-getter` plugin pair
 
 ### Helm 2 Users
 

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -7,8 +7,7 @@ description: |-
   Manage repositories on Google Cloud Storage
 command: "$HELM_PLUGIN_DIR/bin/helm-gcs"
 downloaders:
-  - command: "$HELM_PLUGIN_DIR/bin/helm-gcs"
-    args: ["pull"]
+  - command: "bin/helm-gcs-getter"
     protocols:
       - "gs"
 hooks:

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: "gcs"
-version: "0.8.0"
+version: "0.7.0"
 usage: "Chart repositories on Google Cloud Storage"
 description: |-
   Manage repositories on Google Cloud Storage

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: "gcs"
-version: "0.7.0"
+version: "0.8.0"
 usage: "Chart repositories on Google Cloud Storage"
 description: |-
   Manage repositories on Google Cloud Storage

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,15 +1,34 @@
-# Legacy plugin.yaml for Helm 3 compatibility
-# For Helm 4, use the separate plugins in plugins/gcs/ and plugins/gcs-getter/
 name: "gcs"
 version: "0.7.0"
 usage: "Chart repositories on Google Cloud Storage"
 description: |-
   Manage repositories on Google Cloud Storage
-command: "$HELM_PLUGIN_DIR/bin/helm-gcs"
+platformCommand:
+  - command: "$HELM_PLUGIN_DIR/bin/helm-gcs"
+  - os: windows
+    command: "$HELM_PLUGIN_DIR\\bin\\helm-gcs.exe"
 downloaders:
   - command: "bin/helm-gcs-getter"
     protocols:
       - "gs"
-hooks:
-  install: "cd $HELM_PLUGIN_DIR; ./scripts/install.sh"
-  update: "cd $HELM_PLUGIN_DIR; ./scripts/install.sh"
+platformHooks:
+  install:
+    - command: "$HELM_PLUGIN_DIR/scripts/install.sh"
+    - os: windows
+      command: "powershell.exe"
+      args:
+        - "-NoProfile"
+        - "-ExecutionPolicy"
+        - "Bypass"
+        - "-File"
+        - "$HELM_PLUGIN_DIR\\scripts\\install.ps1"
+  update:
+    - command: "$HELM_PLUGIN_DIR/scripts/install.sh"
+    - os: windows
+      command: "powershell.exe"
+      args:
+        - "-NoProfile"
+        - "-ExecutionPolicy"
+        - "Bypass"
+        - "-File"
+        - "$HELM_PLUGIN_DIR\\scripts\\install.ps1"

--- a/plugins/gcs-getter/plugin.yaml
+++ b/plugins/gcs-getter/plugin.yaml
@@ -10,8 +10,15 @@ config:
     - gs
 
 runtimeConfig:
-  platformCommand:
-    - command: "${HELM_PLUGIN_DIR}/bin/helm-gcs-getter"
-  hooks:
-    install: "cd $HELM_PLUGIN_DIR && ./scripts/install.sh"
-    update: "cd $HELM_PLUGIN_DIR && ./scripts/install.sh"
+  protocolCommands:
+    - protocols:
+        - gs
+      platformCommand:
+        - command: "bin/helm-gcs-getter"
+  platformHooks:
+    install:
+      - command: "sh"
+        args: ["-c", "cd $HELM_PLUGIN_DIR && ./scripts/install.sh"]
+    update:
+      - command: "sh"
+        args: ["-c", "cd $HELM_PLUGIN_DIR && ./scripts/install.sh"]

--- a/plugins/gcs-getter/plugin.yaml
+++ b/plugins/gcs-getter/plugin.yaml
@@ -1,5 +1,5 @@
 name: gcs-getter
-version: "0.8.0"
+version: "0.7.0"
 usage: "gs:// protocol handler for Helm"
 description: |-
   Downloads Helm charts from Google Cloud Storage (GCS) buckets

--- a/plugins/gcs-getter/plugin.yaml
+++ b/plugins/gcs-getter/plugin.yaml
@@ -1,24 +1,35 @@
-apiVersion: v1
-type: getter/v1
 name: gcs-getter
-version: "0.7.0"
-runtime: subprocess
-sourceURL: https://github.com/hayorov/helm-gcs
-
-config:
-  protocols:
-    - gs
-
-runtimeConfig:
-  protocolCommands:
-    - protocols:
-        - gs
-      platformCommand:
-        - command: "bin/helm-gcs-getter"
-  platformHooks:
-    install:
-      - command: "sh"
-        args: ["-c", "cd $HELM_PLUGIN_DIR && ./scripts/install.sh"]
-    update:
-      - command: "sh"
-        args: ["-c", "cd $HELM_PLUGIN_DIR && ./scripts/install.sh"]
+version: "0.8.0"
+usage: "gs:// protocol handler for Helm"
+description: |-
+  Downloads Helm charts from Google Cloud Storage (GCS) buckets
+  using the gs:// protocol scheme.
+downloaders:
+  - command: "bin/helm-gcs-getter"
+    protocols:
+      - "gs"
+platformCommand:
+  - command: "${HELM_PLUGIN_DIR}/bin/helm-gcs-getter"
+  - os: windows
+    command: "${HELM_PLUGIN_DIR}\\bin\\helm-gcs-getter.exe"
+platformHooks:
+  install:
+    - command: "${HELM_PLUGIN_DIR}/scripts/install.sh"
+    - os: windows
+      command: "powershell.exe"
+      args:
+        - "-NoProfile"
+        - "-ExecutionPolicy"
+        - "Bypass"
+        - "-File"
+        - "${HELM_PLUGIN_DIR}\\scripts\\install.ps1"
+  update:
+    - command: "${HELM_PLUGIN_DIR}/scripts/install.sh"
+    - os: windows
+      command: "powershell.exe"
+      args:
+        - "-NoProfile"
+        - "-ExecutionPolicy"
+        - "Bypass"
+        - "-File"
+        - "${HELM_PLUGIN_DIR}\\scripts\\install.ps1"

--- a/plugins/gcs-getter/scripts/install.ps1
+++ b/plugins/gcs-getter/scripts/install.ps1
@@ -1,0 +1,76 @@
+$ErrorActionPreference = "Stop"
+
+if (-not $env:HELM_PLUGIN_DIR) {
+    Write-Error "HELM_PLUGIN_DIR is not set"
+    exit 1
+}
+
+Set-Location $env:HELM_PLUGIN_DIR
+
+if (-not (Test-Path "plugin.yaml")) {
+    Write-Error "plugin.yaml not found in $env:HELM_PLUGIN_DIR"
+    exit 1
+}
+
+$versionLine = Select-String -Path "plugin.yaml" -Pattern 'version:' | Select-Object -First 1
+if (-not $versionLine) {
+    Write-Error "Could not extract version from plugin.yaml"
+    exit 1
+}
+$version = ($versionLine.Line -replace '.*version:\s*"?([^"]+)"?.*', '$1').Trim()
+if (-not $version) {
+    Write-Error "Could not extract version from plugin.yaml"
+    exit 1
+}
+
+Write-Host "Installing helm-gcs-getter plugin ${version}..."
+
+# Detect architecture
+$arch = switch ($env:PROCESSOR_ARCHITECTURE) {
+    "AMD64"  { "x86_64" }
+    "ARM64"  { "arm64" }
+    default  {
+        Write-Error "Unsupported architecture: $env:PROCESSOR_ARCHITECTURE"
+        exit 1
+    }
+}
+
+$url = "https://github.com/hayorov/helm-gcs/releases/download/v${version}/helm-gcs-getter_Windows_${arch}.zip"
+$filename = "helm-gcs-getter_Windows_${arch}.zip"
+
+Write-Host "Downloading from: ${url}"
+
+if (Test-Path "bin") {
+    Remove-Item -Recurse -Force "bin"
+}
+New-Item -ItemType Directory -Path "bin" | Out-Null
+
+try {
+    Invoke-WebRequest -Uri $url -OutFile $filename -UseBasicParsing
+} catch {
+    Write-Error "Failed to download ${url}: $_"
+    exit 1
+}
+
+try {
+    Expand-Archive -Path $filename -DestinationPath "bin" -Force
+} catch {
+    Remove-Item -Force $filename -ErrorAction SilentlyContinue
+    Write-Error "Failed to extract ${filename}: $_"
+    exit 1
+}
+
+Remove-Item -Force $filename -ErrorAction SilentlyContinue
+
+if (-not (Test-Path "bin\helm-gcs-getter.exe")) {
+    Write-Error "helm-gcs-getter.exe binary not found after extraction"
+    exit 1
+}
+
+Write-Host ""
+Write-Host "helm-gcs-getter plugin ${version} installed successfully."
+Write-Host ""
+Write-Host "You can now use gs:// URLs with Helm:"
+Write-Host "  helm repo add myrepo gs://bucket/path"
+Write-Host "  helm pull gs://bucket/path/chart-1.0.0.tgz"
+Write-Host ""

--- a/plugins/gcs-getter/scripts/install.sh
+++ b/plugins/gcs-getter/scripts/install.sh
@@ -45,8 +45,14 @@ case "$arch" in
         ;;
 esac
 
-url="https://github.com/hayorov/helm-gcs/releases/download/v${version}/helm-gcs-getter_${os}_${arch}.tar.gz"
-filename="helm-gcs-getter_${os}_${arch}.tar.gz"
+if [ "$os" = "Windows" ]; then
+    ext="zip"
+else
+    ext="tar.gz"
+fi
+
+url="https://github.com/hayorov/helm-gcs/releases/download/v${version}/helm-gcs-getter_${os}_${arch}.${ext}"
+filename="helm-gcs-getter_${os}_${arch}.${ext}"
 
 echo "Downloading from: ${url}"
 
@@ -67,11 +73,19 @@ else
     exit 1
 fi
 
-tar xzf "$filename" -C bin || {
-    echo "Error: Failed to extract $filename"
-    rm -f "$filename"
-    exit 1
-}
+if [ "$ext" = "zip" ]; then
+    unzip -q -o "$filename" -d bin || {
+        echo "Error: Failed to extract $filename"
+        rm -f "$filename"
+        exit 1
+    }
+else
+    tar xzf "$filename" -C bin || {
+        echo "Error: Failed to extract $filename"
+        rm -f "$filename"
+        exit 1
+    }
+fi
 
 rm -f "$filename"
 

--- a/plugins/gcs/plugin.yaml
+++ b/plugins/gcs/plugin.yaml
@@ -25,6 +25,10 @@ config:
 runtimeConfig:
   platformCommand:
     - command: "${HELM_PLUGIN_DIR}/bin/helm-gcs"
-  hooks:
-    install: "cd $HELM_PLUGIN_DIR && ./scripts/install.sh"
-    update: "cd $HELM_PLUGIN_DIR && ./scripts/install.sh"
+  platformHooks:
+    install:
+      - command: "sh"
+        args: ["-c", "cd $HELM_PLUGIN_DIR && ./scripts/install.sh"]
+    update:
+      - command: "sh"
+        args: ["-c", "cd $HELM_PLUGIN_DIR && ./scripts/install.sh"]

--- a/plugins/gcs/plugin.yaml
+++ b/plugins/gcs/plugin.yaml
@@ -1,34 +1,40 @@
-apiVersion: v1
-type: cli/v1
 name: gcs
-version: "0.7.0"
-runtime: subprocess
-sourceURL: https://github.com/hayorov/helm-gcs
+version: "0.8.0"
+usage: "gcs <command> [flags]"
+description: |-
+  Manage Helm chart repositories on Google Cloud Storage (GCS) buckets.
 
-config:
-  usage: "gcs <command> [flags]"
-  shortHelp: "Manage Helm chart repositories on Google Cloud Storage"
-  longHelp: |
-    The gcs plugin allows you to manage Helm chart repositories
-    stored in Google Cloud Storage (GCS) buckets.
+  Commands:
+    init   Initialize a new chart repository in a GCS bucket
+    push   Push a chart to a GCS repository
+    rm     Remove a chart from a GCS repository
 
-    Commands:
-      init   Initialize a new chart repository in a GCS bucket
-      push   Push a chart to a GCS repository  
-      rm     Remove a chart from a GCS repository
-
-    Examples:
-      helm gcs init gs://my-bucket/charts
-      helm gcs push mychart-0.1.0.tgz my-repo
-      helm gcs rm mychart my-repo --version 0.1.0
-
-runtimeConfig:
-  platformCommand:
-    - command: "${HELM_PLUGIN_DIR}/bin/helm-gcs"
-  platformHooks:
-    install:
-      - command: "sh"
-        args: ["-c", "cd $HELM_PLUGIN_DIR && ./scripts/install.sh"]
-    update:
-      - command: "sh"
-        args: ["-c", "cd $HELM_PLUGIN_DIR && ./scripts/install.sh"]
+  Examples:
+    helm gcs init gs://my-bucket/charts
+    helm gcs push mychart-0.1.0.tgz my-repo
+    helm gcs rm mychart my-repo --version 0.1.0
+platformCommand:
+  - command: "${HELM_PLUGIN_DIR}/bin/helm-gcs"
+  - os: windows
+    command: "${HELM_PLUGIN_DIR}\\bin\\helm-gcs.exe"
+platformHooks:
+  install:
+    - command: "${HELM_PLUGIN_DIR}/scripts/install.sh"
+    - os: windows
+      command: "powershell.exe"
+      args:
+        - "-NoProfile"
+        - "-ExecutionPolicy"
+        - "Bypass"
+        - "-File"
+        - "${HELM_PLUGIN_DIR}\\scripts\\install.ps1"
+  update:
+    - command: "${HELM_PLUGIN_DIR}/scripts/install.sh"
+    - os: windows
+      command: "powershell.exe"
+      args:
+        - "-NoProfile"
+        - "-ExecutionPolicy"
+        - "Bypass"
+        - "-File"
+        - "${HELM_PLUGIN_DIR}\\scripts\\install.ps1"

--- a/plugins/gcs/plugin.yaml
+++ b/plugins/gcs/plugin.yaml
@@ -1,5 +1,5 @@
 name: gcs
-version: "0.8.0"
+version: "0.7.0"
 usage: "gcs <command> [flags]"
 description: |-
   Manage Helm chart repositories on Google Cloud Storage (GCS) buckets.

--- a/plugins/gcs/scripts/install.ps1
+++ b/plugins/gcs/scripts/install.ps1
@@ -1,0 +1,77 @@
+$ErrorActionPreference = "Stop"
+
+if (-not $env:HELM_PLUGIN_DIR) {
+    Write-Error "HELM_PLUGIN_DIR is not set"
+    exit 1
+}
+
+Set-Location $env:HELM_PLUGIN_DIR
+
+if (-not (Test-Path "plugin.yaml")) {
+    Write-Error "plugin.yaml not found in $env:HELM_PLUGIN_DIR"
+    exit 1
+}
+
+$versionLine = Select-String -Path "plugin.yaml" -Pattern 'version:' | Select-Object -First 1
+if (-not $versionLine) {
+    Write-Error "Could not extract version from plugin.yaml"
+    exit 1
+}
+$version = ($versionLine.Line -replace '.*version:\s*"?([^"]+)"?.*', '$1').Trim()
+if (-not $version) {
+    Write-Error "Could not extract version from plugin.yaml"
+    exit 1
+}
+
+Write-Host "Installing helm-gcs CLI plugin ${version}..."
+
+# Detect architecture
+$arch = switch ($env:PROCESSOR_ARCHITECTURE) {
+    "AMD64"  { "x86_64" }
+    "ARM64"  { "arm64" }
+    default  {
+        Write-Error "Unsupported architecture: $env:PROCESSOR_ARCHITECTURE"
+        exit 1
+    }
+}
+
+$url = "https://github.com/hayorov/helm-gcs/releases/download/v${version}/helm-gcs_Windows_${arch}.zip"
+$filename = "helm-gcs_Windows_${arch}.zip"
+
+Write-Host "Downloading from: ${url}"
+
+if (Test-Path "bin") {
+    Remove-Item -Recurse -Force "bin"
+}
+New-Item -ItemType Directory -Path "bin" | Out-Null
+
+try {
+    Invoke-WebRequest -Uri $url -OutFile $filename -UseBasicParsing
+} catch {
+    Write-Error "Failed to download ${url}: $_"
+    exit 1
+}
+
+try {
+    Expand-Archive -Path $filename -DestinationPath "bin" -Force
+} catch {
+    Remove-Item -Force $filename -ErrorAction SilentlyContinue
+    Write-Error "Failed to extract ${filename}: $_"
+    exit 1
+}
+
+Remove-Item -Force $filename -ErrorAction SilentlyContinue
+
+if (-not (Test-Path "bin\helm-gcs.exe")) {
+    Write-Error "helm-gcs.exe binary not found after extraction"
+    exit 1
+}
+
+Write-Host ""
+Write-Host "helm-gcs CLI plugin ${version} installed successfully."
+Write-Host ""
+Write-Host "Usage:"
+Write-Host "  helm gcs init gs://bucket/path       # Initialize repository"
+Write-Host "  helm gcs push chart.tgz repo-name    # Push a chart"
+Write-Host "  helm gcs rm chart repo-name          # Remove a chart"
+Write-Host ""

--- a/plugins/gcs/scripts/install.sh
+++ b/plugins/gcs/scripts/install.sh
@@ -45,8 +45,14 @@ case "$arch" in
         ;;
 esac
 
-url="https://github.com/hayorov/helm-gcs/releases/download/v${version}/helm-gcs_${os}_${arch}.tar.gz"
-filename="helm-gcs_${os}_${arch}.tar.gz"
+if [ "$os" = "Windows" ]; then
+    ext="zip"
+else
+    ext="tar.gz"
+fi
+
+url="https://github.com/hayorov/helm-gcs/releases/download/v${version}/helm-gcs_${os}_${arch}.${ext}"
+filename="helm-gcs_${os}_${arch}.${ext}"
 
 echo "Downloading from: ${url}"
 
@@ -67,11 +73,19 @@ else
     exit 1
 fi
 
-tar xzf "$filename" -C bin || {
-    echo "Error: Failed to extract $filename"
-    rm -f "$filename"
-    exit 1
-}
+if [ "$ext" = "zip" ]; then
+    unzip -q -o "$filename" -d bin || {
+        echo "Error: Failed to extract $filename"
+        rm -f "$filename"
+        exit 1
+    }
+else
+    tar xzf "$filename" -C bin || {
+        echo "Error: Failed to extract $filename"
+        rm -f "$filename"
+        exit 1
+    }
+fi
 
 rm -f "$filename"
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -9,20 +9,76 @@ if (-not $env:HELM_PLUGIN_DIR) {
 Set-Location $env:HELM_PLUGIN_DIR
 
 # Extract version from plugin.yaml
-if (-not (Test-Path "plugin.yaml")) {
+# On Helm 4 the install hook runs after plugin.yaml is renamed, so check .bak too
+$pluginFile = if (Test-Path "plugin.yaml") { "plugin.yaml" }
+              elseif (Test-Path "plugin.yaml.bak") { "plugin.yaml.bak" }
+              else { $null }
+if (-not $pluginFile) {
     Write-Error "plugin.yaml not found in $env:HELM_PLUGIN_DIR"
     exit 1
 }
 
-$versionLine = Select-String -Path "plugin.yaml" -Pattern 'version:' | Select-Object -First 1
+$versionLine = Select-String -Path $pluginFile -Pattern 'version:' | Select-Object -First 1
 if (-not $versionLine) {
-    Write-Error "Could not extract version from plugin.yaml"
+    Write-Error "Could not extract version from $pluginFile"
     exit 1
 }
 $version = ($versionLine.Line -replace '.*version:\s*"?([^"]+)"?.*', '$1').Trim()
 if (-not $version) {
-    Write-Error "Could not extract version from plugin.yaml"
+    Write-Error "Could not extract version from $pluginFile"
     exit 1
+}
+
+# Detect architecture
+$arch = switch ($env:PROCESSOR_ARCHITECTURE) {
+    "AMD64"  { "x86_64" }
+    "ARM64"  { "arm64" }
+    default  {
+        Write-Error "Unsupported architecture: $env:PROCESSOR_ARCHITECTURE"
+        exit 1
+    }
+}
+
+$baseUrl = "https://github.com/hayorov/helm-gcs/releases/download/v${version}"
+
+function Download-Binary {
+    param(
+        [string]$Binary,
+        [string]$Dest
+    )
+
+    if (-not (Test-Path $Dest)) {
+        New-Item -ItemType Directory -Path $Dest -Force | Out-Null
+    }
+
+    $filename = "${Binary}_Windows_${arch}.zip"
+    $url = "${baseUrl}/${filename}"
+    $outPath = Join-Path $Dest $filename
+
+    Write-Host "Downloading from: ${url}"
+
+    try {
+        Invoke-WebRequest -Uri $url -OutFile $outPath -UseBasicParsing
+    } catch {
+        Write-Error "Failed to download ${url}: $_"
+        exit 1
+    }
+
+    try {
+        Expand-Archive -Path $outPath -DestinationPath $Dest -Force
+    } catch {
+        Remove-Item -Force $outPath -ErrorAction SilentlyContinue
+        Write-Error "Failed to extract ${filename}: $_"
+        exit 1
+    }
+
+    Remove-Item -Force $outPath -ErrorAction SilentlyContinue
+
+    $exePath = Join-Path $Dest "${Binary}.exe"
+    if (-not (Test-Path $exePath)) {
+        Write-Error "${Binary}.exe not found after extraction in ${Dest}"
+        exit 1
+    }
 }
 
 # Detect Helm version using $HELM_BIN (set by Helm itself) to avoid
@@ -38,39 +94,53 @@ try {
     # helm not found or version failed; fall through
 }
 
-# For Helm 4, recommend using the separate plugin packages
 if ($helmMajorVersion -eq "4") {
-    Write-Host ""
-    Write-Host "=========================================="
-    Write-Host "  Helm 4 Detected"
-    Write-Host "=========================================="
-    Write-Host ""
-    Write-Host "For Helm 4, we recommend installing the separate plugin packages"
-    Write-Host "for better compatibility with the new plugin system:"
-    Write-Host ""
-    Write-Host "  # CLI plugin (helm gcs init/push/rm)"
-    Write-Host "  helm plugin install https://github.com/hayorov/helm-gcs/releases/download/v${version}/helm-gcs-plugin.tar.gz"
-    Write-Host ""
-    Write-Host "  # Getter plugin (gs:// protocol support)"
-    Write-Host "  helm plugin install https://github.com/hayorov/helm-gcs/releases/download/v${version}/helm-gcs-getter-plugin.tar.gz"
-    Write-Host ""
-    Write-Host "Continuing with legacy installation..."
-    Write-Host ""
-}
+    Write-Host "Helm 4 detected -- installing sub-plugins for full cli + getter support..."
 
-Write-Host "Installing helm-gcs ${version} ..."
+    $pluginsDir = Split-Path $env:HELM_PLUGIN_DIR -Parent
 
-# Detect architecture
-$arch = switch ($env:PROCESSOR_ARCHITECTURE) {
-    "AMD64"  { "x86_64" }
-    "ARM64"  { "arm64" }
-    default  {
-        Write-Error "Unsupported architecture: $env:PROCESSOR_ARCHITECTURE"
-        exit 1
+    $entries = @(
+        @{ SrcDir = "gcs";        Binary = "helm-gcs";        DestName = "helm-gcs-plugin" },
+        @{ SrcDir = "gcs-getter"; Binary = "helm-gcs-getter"; DestName = "helm-gcs-getter-plugin" }
+    )
+
+    foreach ($entry in $entries) {
+        $src  = Join-Path $env:HELM_PLUGIN_DIR "plugins\$($entry.SrcDir)"
+        $dest = Join-Path $pluginsDir $entry.DestName
+
+        if (-not (Test-Path $src)) {
+            Write-Error "Sub-plugin source not found: $src"
+            exit 1
+        }
+
+        if (Test-Path $dest) {
+            Remove-Item -Recurse -Force $dest
+        }
+        Copy-Item -Recurse $src $dest
+
+        $binDir = Join-Path $dest "bin"
+        Download-Binary -Binary $entry.Binary -Dest $binDir
     }
+
+    # Disable the root plugin so Helm 4 doesn't see a duplicate "gcs" plugin
+    $rootYaml = Join-Path $env:HELM_PLUGIN_DIR "plugin.yaml"
+    if (Test-Path $rootYaml) {
+        Rename-Item $rootYaml "plugin.yaml.bak" -Force -ErrorAction SilentlyContinue
+    }
+
+    Write-Host ""
+    Write-Host "helm-gcs ${version} installed for Helm 4."
+    Write-Host ""
+    Write-Host "  helm gcs init gs://bucket/path         # Initialize repository"
+    Write-Host "  helm repo add myrepo gs://bucket/path   # Add repository"
+    Write-Host "  helm gcs push chart.tgz myrepo          # Push a chart"
+    Write-Host "  helm gcs rm chart myrepo                # Remove a chart"
+    Write-Host ""
+    exit 0
 }
 
-$baseUrl = "https://github.com/hayorov/helm-gcs/releases/download/v${version}"
+# Helm 3: legacy single-plugin install (both binaries into this plugin's bin/)
+Write-Host "Installing helm-gcs ${version} ..."
 
 if (Test-Path "bin") {
     Remove-Item -Recurse -Force "bin"
@@ -78,38 +148,7 @@ if (Test-Path "bin") {
 New-Item -ItemType Directory -Path "bin" | Out-Null
 
 foreach ($binary in @("helm-gcs", "helm-gcs-getter")) {
-    $filename = "${binary}_Windows_${arch}.zip"
-    $url = "${baseUrl}/${filename}"
-
-    Write-Host "Downloading from: ${url}"
-
-    try {
-        Invoke-WebRequest -Uri $url -OutFile $filename -UseBasicParsing
-    } catch {
-        Write-Error "Failed to download ${url}: $_"
-        exit 1
-    }
-
-    try {
-        Expand-Archive -Path $filename -DestinationPath "bin" -Force
-    } catch {
-        Remove-Item -Force $filename -ErrorAction SilentlyContinue
-        Write-Error "Failed to extract ${filename}: $_"
-        exit 1
-    }
-
-    Remove-Item -Force $filename -ErrorAction SilentlyContinue
-}
-
-# Verify installation
-if (-not (Test-Path "bin\helm-gcs.exe")) {
-    Write-Error "helm-gcs.exe binary not found after extraction"
-    exit 1
-}
-
-if (-not (Test-Path "bin\helm-gcs-getter.exe")) {
-    Write-Error "helm-gcs-getter.exe binary not found after extraction"
-    exit 1
+    Download-Binary -Binary $binary -Dest "bin"
 }
 
 Write-Host ""

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,124 @@
+$ErrorActionPreference = "Stop"
+
+# Ensure we're in the plugin directory
+if (-not $env:HELM_PLUGIN_DIR) {
+    Write-Error "HELM_PLUGIN_DIR is not set"
+    exit 1
+}
+
+Set-Location $env:HELM_PLUGIN_DIR
+
+# Extract version from plugin.yaml
+if (-not (Test-Path "plugin.yaml")) {
+    Write-Error "plugin.yaml not found in $env:HELM_PLUGIN_DIR"
+    exit 1
+}
+
+$versionLine = Select-String -Path "plugin.yaml" -Pattern 'version:' | Select-Object -First 1
+if (-not $versionLine) {
+    Write-Error "Could not extract version from plugin.yaml"
+    exit 1
+}
+$version = ($versionLine.Line -replace '.*version:\s*"?([^"]+)"?.*', '$1').Trim()
+if (-not $version) {
+    Write-Error "Could not extract version from plugin.yaml"
+    exit 1
+}
+
+# Detect Helm version using $HELM_BIN (set by Helm itself) to avoid
+# picking up a different helm version that happens to be on PATH.
+$helmBin = if ($env:HELM_BIN) { $env:HELM_BIN } else { "helm" }
+$helmMajorVersion = ""
+try {
+    $helmVersionOutput = & $helmBin version --short 2>$null
+    if ($helmVersionOutput -match 'v(\d+)') {
+        $helmMajorVersion = $Matches[1]
+    }
+} catch {
+    # helm not found or version failed; fall through
+}
+
+# For Helm 4, recommend using the separate plugin packages
+if ($helmMajorVersion -eq "4") {
+    Write-Host ""
+    Write-Host "=========================================="
+    Write-Host "  Helm 4 Detected"
+    Write-Host "=========================================="
+    Write-Host ""
+    Write-Host "For Helm 4, we recommend installing the separate plugin packages"
+    Write-Host "for better compatibility with the new plugin system:"
+    Write-Host ""
+    Write-Host "  # CLI plugin (helm gcs init/push/rm)"
+    Write-Host "  helm plugin install https://github.com/hayorov/helm-gcs/releases/download/v${version}/helm-gcs-plugin.tar.gz"
+    Write-Host ""
+    Write-Host "  # Getter plugin (gs:// protocol support)"
+    Write-Host "  helm plugin install https://github.com/hayorov/helm-gcs/releases/download/v${version}/helm-gcs-getter-plugin.tar.gz"
+    Write-Host ""
+    Write-Host "Continuing with legacy installation..."
+    Write-Host ""
+}
+
+Write-Host "Installing helm-gcs ${version} ..."
+
+# Detect architecture
+$arch = switch ($env:PROCESSOR_ARCHITECTURE) {
+    "AMD64"  { "x86_64" }
+    "ARM64"  { "arm64" }
+    default  {
+        Write-Error "Unsupported architecture: $env:PROCESSOR_ARCHITECTURE"
+        exit 1
+    }
+}
+
+$baseUrl = "https://github.com/hayorov/helm-gcs/releases/download/v${version}"
+
+if (Test-Path "bin") {
+    Remove-Item -Recurse -Force "bin"
+}
+New-Item -ItemType Directory -Path "bin" | Out-Null
+
+foreach ($binary in @("helm-gcs", "helm-gcs-getter")) {
+    $filename = "${binary}_Windows_${arch}.zip"
+    $url = "${baseUrl}/${filename}"
+
+    Write-Host "Downloading from: ${url}"
+
+    try {
+        Invoke-WebRequest -Uri $url -OutFile $filename -UseBasicParsing
+    } catch {
+        Write-Error "Failed to download ${url}: $_"
+        exit 1
+    }
+
+    try {
+        Expand-Archive -Path $filename -DestinationPath "bin" -Force
+    } catch {
+        Remove-Item -Force $filename -ErrorAction SilentlyContinue
+        Write-Error "Failed to extract ${filename}: $_"
+        exit 1
+    }
+
+    Remove-Item -Force $filename -ErrorAction SilentlyContinue
+}
+
+# Verify installation
+if (-not (Test-Path "bin\helm-gcs.exe")) {
+    Write-Error "helm-gcs.exe binary not found after extraction"
+    exit 1
+}
+
+if (-not (Test-Path "bin\helm-gcs-getter.exe")) {
+    Write-Error "helm-gcs-getter.exe binary not found after extraction"
+    exit 1
+}
+
+Write-Host ""
+Write-Host "helm-gcs ${version} is correctly installed."
+Write-Host ""
+Write-Host "Usage:"
+Write-Host "  helm gcs init gs://bucket/path              # Initialize repository"
+Write-Host "  helm repo add repo-name gs://bucket/path    # Add repository to Helm"
+Write-Host "  helm gcs push chart.tgz repo-name           # Push a chart"
+Write-Host "  helm repo update                            # Update Helm cache"
+Write-Host "  helm fetch repo-name/chart                  # Fetch a chart"
+Write-Host ""

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -60,7 +60,7 @@ case "${unameOut}" in
     Linux*)             os=Linux;;
     Darwin*)            os=Darwin;;
     CYGWIN*)            os=Cygwin;;
-    MINGW*|MSYS_NT*)    os=windows;;
+    MINGW*|MSYS_NT*)    os=Windows;;
     *)
         echo "Unsupported OS: ${unameOut}"
         exit 1
@@ -79,48 +79,71 @@ case "${arch}" in
         ;;
 esac
 
-url="https://github.com/hayorov/helm-gcs/releases/download/v${version}/helm-gcs_${os}_${arch}.tar.gz"
-filename="helm-gcs_${os}_${arch}.tar.gz"
-
-echo "Downloading from: ${url}"
-
-# Download archive
-if command -v curl > /dev/null 2>&1; then
-    if ! curl -sSL -o "$filename" "$url"; then
-        echo "Error: Failed to download $url"
-        exit 1
-    fi
-elif command -v wget > /dev/null 2>&1; then
-    if ! wget -q -O "$filename" "$url"; then
-        echo "Error: Failed to download $url"
-        exit 1
-    fi
+if [ "$os" = "Windows" ]; then
+    ext="zip"
 else
-    echo "Error: curl or wget is required"
-    exit 1
+    ext="tar.gz"
 fi
 
-# Verify download
-if [ ! -f "$filename" ]; then
-    echo "Error: Downloaded file not found: $filename"
-    exit 1
-fi
-
-# Install binary
 rm -rf bin
 mkdir -p bin
 
-if ! tar xzf "$filename" -C bin; then
-    echo "Error: Failed to extract $filename"
+base_url="https://github.com/hayorov/helm-gcs/releases/download/v${version}"
+
+for binary in helm-gcs helm-gcs-getter; do
+    filename="${binary}_${os}_${arch}.${ext}"
+    url="${base_url}/${filename}"
+
+    echo "Downloading from: ${url}"
+
+    # Download archive
+    if command -v curl > /dev/null 2>&1; then
+        if ! curl -sSL -o "$filename" "$url"; then
+            echo "Error: Failed to download $url"
+            exit 1
+        fi
+    elif command -v wget > /dev/null 2>&1; then
+        if ! wget -q -O "$filename" "$url"; then
+            echo "Error: Failed to download $url"
+            exit 1
+        fi
+    else
+        echo "Error: curl or wget is required"
+        exit 1
+    fi
+
+    # Verify download
+    if [ ! -f "$filename" ]; then
+        echo "Error: Downloaded file not found: $filename"
+        exit 1
+    fi
+
+    # Extract archive
+    if [ "$ext" = "zip" ]; then
+        if ! unzip -q -o "$filename" -d bin; then
+            echo "Error: Failed to extract $filename"
+            rm -f "$filename"
+            exit 1
+        fi
+    else
+        if ! tar xzf "$filename" -C bin; then
+            echo "Error: Failed to extract $filename"
+            rm -f "$filename"
+            exit 1
+        fi
+    fi
+
     rm -f "$filename"
+done
+
+# Verify installation
+if [ ! -x "bin/helm-gcs" ] && [ ! -f "bin/helm-gcs.exe" ]; then
+    echo "Error: helm-gcs binary not found or not executable"
     exit 1
 fi
 
-rm -f "$filename"
-
-# Verify installation
-if [ ! -x "bin/helm-gcs" ]; then
-    echo "Error: helm-gcs binary not found or not executable"
+if [ ! -x "bin/helm-gcs-getter" ] && [ ! -f "bin/helm-gcs-getter.exe" ]; then
+    echo "Error: helm-gcs-getter binary not found or not executable"
     exit 1
 fi
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -25,10 +25,12 @@ if [ -z "$version" ]; then
     exit 1
 fi
 
-# Detect Helm version
+# Detect Helm version using $HELM_BIN (set by Helm itself) to avoid
+# picking up a different helm version that happens to be on PATH.
 helm_major_version=""
-if command -v helm > /dev/null 2>&1; then
-    helm_version_output=$(helm version --short 2>/dev/null || echo "")
+helm_bin="${HELM_BIN:-helm}"
+if command -v "$helm_bin" > /dev/null 2>&1; then
+    helm_version_output=$("$helm_bin" version --short 2>/dev/null || echo "")
     helm_major_version=$(echo "$helm_version_output" | grep -oE 'v[0-9]+' | head -1 | tr -d 'v')
 fi
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -25,36 +25,6 @@ if [ -z "$version" ]; then
     exit 1
 fi
 
-# Detect Helm version using $HELM_BIN (set by Helm itself) to avoid
-# picking up a different helm version that happens to be on PATH.
-helm_major_version=""
-helm_bin="${HELM_BIN:-helm}"
-if command -v "$helm_bin" > /dev/null 2>&1; then
-    helm_version_output=$("$helm_bin" version --short 2>/dev/null || echo "")
-    helm_major_version=$(echo "$helm_version_output" | grep -oE 'v[0-9]+' | head -1 | tr -d 'v')
-fi
-
-# For Helm 4, recommend using the separate plugin packages
-if [ "$helm_major_version" = "4" ]; then
-    echo ""
-    echo "=========================================="
-    echo "  Helm 4 Detected"
-    echo "=========================================="
-    echo ""
-    echo "For Helm 4, we recommend installing the separate plugin packages"
-    echo "for better compatibility with the new plugin system:"
-    echo ""
-    echo "  # CLI plugin (helm gcs init/push/rm)"
-    echo "  helm plugin install https://github.com/hayorov/helm-gcs/releases/download/v${version}/helm-gcs-plugin.tar.gz"
-    echo ""
-    echo "  # Getter plugin (gs:// protocol support)"
-    echo "  helm plugin install https://github.com/hayorov/helm-gcs/releases/download/v${version}/helm-gcs-getter-plugin.tar.gz"
-    echo ""
-    echo "Continuing with legacy installation..."
-    echo ""
-fi
-
-echo "Installing helm-gcs ${version} ..."
 
 # Detect OS
 unameOut="$(uname -s)"
@@ -87,25 +57,26 @@ else
     ext="tar.gz"
 fi
 
-rm -rf bin
-mkdir -p bin
-
 base_url="https://github.com/hayorov/helm-gcs/releases/download/v${version}"
 
-for binary in helm-gcs helm-gcs-getter; do
+# Download and extract a binary into a target directory
+download_binary() {
+    binary="$1"
+    dest="$2"
+
+    mkdir -p "$dest"
     filename="${binary}_${os}_${arch}.${ext}"
     url="${base_url}/${filename}"
 
     echo "Downloading from: ${url}"
 
-    # Download archive
     if command -v curl > /dev/null 2>&1; then
-        if ! curl -sSL -o "$filename" "$url"; then
+        if ! curl -sSL -o "${dest}/${filename}" "$url"; then
             echo "Error: Failed to download $url"
             exit 1
         fi
     elif command -v wget > /dev/null 2>&1; then
-        if ! wget -q -O "$filename" "$url"; then
+        if ! wget -q -O "${dest}/${filename}" "$url"; then
             echo "Error: Failed to download $url"
             exit 1
         fi
@@ -114,40 +85,91 @@ for binary in helm-gcs helm-gcs-getter; do
         exit 1
     fi
 
-    # Verify download
-    if [ ! -f "$filename" ]; then
-        echo "Error: Downloaded file not found: $filename"
+    if [ ! -f "${dest}/${filename}" ]; then
+        echo "Error: Downloaded file not found: ${dest}/${filename}"
         exit 1
     fi
 
-    # Extract archive
     if [ "$ext" = "zip" ]; then
-        if ! unzip -q -o "$filename" -d bin; then
-            echo "Error: Failed to extract $filename"
-            rm -f "$filename"
+        if ! unzip -q -o "${dest}/${filename}" -d "$dest"; then
+            echo "Error: Failed to extract ${filename}"
+            rm -f "${dest}/${filename}"
             exit 1
         fi
     else
-        if ! tar xzf "$filename" -C bin; then
-            echo "Error: Failed to extract $filename"
-            rm -f "$filename"
+        if ! tar xzf "${dest}/${filename}" -C "$dest"; then
+            echo "Error: Failed to extract ${filename}"
+            rm -f "${dest}/${filename}"
             exit 1
         fi
     fi
 
-    rm -f "$filename"
+    rm -f "${dest}/${filename}"
+
+    if [ ! -x "${dest}/${binary}" ] && [ ! -f "${dest}/${binary}.exe" ]; then
+        echo "Error: ${binary} not found after extraction"
+        exit 1
+    fi
+}
+
+# Detect Helm version using $HELM_BIN (set by Helm itself) to avoid
+# picking up a different helm version that happens to be on PATH.
+helm_major_version=""
+helm_bin="${HELM_BIN:-helm}"
+if command -v "$helm_bin" > /dev/null 2>&1; then
+    helm_version_output=$("$helm_bin" version --short 2>/dev/null || echo "")
+    helm_major_version=$(echo "$helm_version_output" | grep -oE 'v[0-9]+' | head -1 | tr -d 'v')
+fi
+
+# Helm 4: install the two sub-plugins directly, then disable the root plugin
+if [ "$helm_major_version" = "4" ]; then
+    echo "Helm 4 detected -- installing sub-plugins for full cli + getter support..."
+
+    plugins_dir="$(dirname "$HELM_PLUGIN_DIR")"
+
+    for entry in gcs:helm-gcs:helm-gcs-plugin gcs-getter:helm-gcs-getter:helm-gcs-getter-plugin; do
+        src_dir="${entry%%:*}"                          # gcs or gcs-getter
+        rest="${entry#*:}"
+        binary="${rest%%:*}"                            # helm-gcs or helm-gcs-getter
+        dest_name="${rest#*:}"                          # helm-gcs-plugin or helm-gcs-getter-plugin
+
+        src="$HELM_PLUGIN_DIR/plugins/${src_dir}"
+        dest="${plugins_dir}/${dest_name}"
+
+        if [ ! -d "$src" ]; then
+            echo "Error: sub-plugin source not found: $src"
+            exit 1
+        fi
+
+        rm -rf "$dest"
+        cp -r "$src" "$dest"
+        download_binary "$binary" "$dest/bin"
+    done
+
+    # Disable the root plugin so Helm 4 doesn't see a duplicate "gcs" plugin.
+    # We rename rather than delete in case this is a local dev checkout.
+    mv -f "$HELM_PLUGIN_DIR/plugin.yaml" "$HELM_PLUGIN_DIR/plugin.yaml.bak" 2>/dev/null || true
+
+    echo ""
+    echo "helm-gcs ${version} installed for Helm 4."
+    echo ""
+    echo "  helm gcs init gs://bucket/path         # Initialize repository"
+    echo "  helm repo add myrepo gs://bucket/path   # Add repository"
+    echo "  helm gcs push chart.tgz myrepo          # Push a chart"
+    echo "  helm gcs rm chart myrepo                # Remove a chart"
+    echo ""
+    exit 0
+fi
+
+# Helm 3: legacy single-plugin install (both binaries into this plugin's bin/)
+echo "Installing helm-gcs ${version} ..."
+
+rm -rf bin
+mkdir -p bin
+
+for binary in helm-gcs helm-gcs-getter; do
+    download_binary "$binary" bin
 done
-
-# Verify installation
-if [ ! -x "bin/helm-gcs" ] && [ ! -f "bin/helm-gcs.exe" ]; then
-    echo "Error: helm-gcs binary not found or not executable"
-    exit 1
-fi
-
-if [ ! -x "bin/helm-gcs-getter" ] && [ ! -f "bin/helm-gcs-getter.exe" ]; then
-    echo "Error: helm-gcs-getter binary not found or not executable"
-    exit 1
-fi
 
 echo ""
 echo "helm-gcs ${version} is correctly installed."


### PR DESCRIPTION
Converted hooks to platformHooks in both sub-plugin plugin.yaml files so install hooks actually fire on Helm 4 (hooks field is silently dropped during v1 remarshal).

The getter plugin needed protocolCommands instead of platformCommand -- without it Helm 4 finds the plugin for gs:// but has no command to run, so "no downloader found for protocol gs".

Also added a release workflow step to package sub-plugin tarballs with the wrapper directory Helm 4's LocalInstaller expects.

With this change, **_a single helm plugin install command works to install this plugin for either helm3 and helm4_**, on windows and unix. It's a single unified install command for either helm version or OS.

Note: This change is rebased off of my other PR #256 for windows compatibility.